### PR TITLE
fix: the logout flow only clears local indexeddb sto... in SimpleESI.js

### DIFF
--- a/js/SimpleESI.js
+++ b/js/SimpleESI.js
@@ -68,6 +68,7 @@ class SimpleESI {
 
 		this.ssoAuthUrl = 'https://login.eveonline.com/v2/oauth/authorize/';
 		this.ssoTokenUrl = 'https://login.eveonline.com/v2/oauth/token';
+		this.ssoRevokeUrl = 'https://login.eveonline.com/v2/oauth/revoke';
 
 		const compatibility_date = '2020-01-01';
 
@@ -139,6 +140,20 @@ class SimpleESI {
 
 	async authLogout(destructive = true, redirectToRoot = true) {
 		await this.ready;
+		if (this.whoami && this.whoami.character_id) {
+			try {
+				const authed_json = await this.lsGet('authed_json', this.whoami.character_id);
+				if (authed_json && authed_json.refresh_token) {
+					await this.doRequest(this.ssoRevokeUrl, 'POST', this.mimetypeForm, {
+						token_type_hint: 'refresh_token',
+						token: authed_json.refresh_token,
+						client_id: this.ssoClientId
+					});
+				}
+			} catch (err) {
+				this.errorlogger('Failed to revoke token on logout:', err);
+			}
+		}
 		if (destructive) {
 			this.whoami = null;
 			await this.store.destroyDB();


### PR DESCRIPTION
## Summary
Fix high severity security issue in `js/SimpleESI.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `js/SimpleESI.js:100` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The logout flow only clears local IndexedDB storage without calling the EVE Online SSO token revocation endpoint. Stolen refresh tokens remain valid after logout and can be used to obtain new access tokens indefinitely until natural expiration.

## Evidence

**Exploitation scenario**: Attacker with previously exfiltrated refresh token (via XSS or storage access) continues using it after victim logs out, calling EVE SSO token endpoint to obtain new access tokens for persistent.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `js/SimpleESI.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
